### PR TITLE
Adds option to override the theme's icons through monochrome icons and fixes string encoding issues

### DIFF
--- a/libqnotero/_themes/default.py
+++ b/libqnotero/_themes/default.py
@@ -41,7 +41,7 @@ class Default:
 		self.setWindowProperties()
 		self.setScrollBars()
 		
-	def icon(self, iconName):
+	def icon(self, iconName, overrideIconExt=None):
 	
 		"""
 		Retrieves an icon from the theme
@@ -53,8 +53,8 @@ class Default:
 		A QIcon		
 		"""
 	
-		return QIcon(os.path.join(self._themeFolder, iconName) \
-			+ self._iconExt)
+		iconExt = self._iconExt if overrideIconExt is None else overrideIconExt
+		return QIcon(os.path.join(self._themeFolder, iconName) + iconExt)
 			
 	def iconExt(self):
 	

--- a/libqnotero/config.py
+++ b/libqnotero/config.py
@@ -29,6 +29,7 @@ config = {
 	u"noteProvider" : u"gnote",
 	u"pdfReader" : u"xdg-open",
 	u"theme" : u"Default",
+	u"iconOverride" : u"",
 	u"updateUrl" : \
 		u"http://files.cogsci.nl/software/qnotero/MOST_RECENT_VERSION.TXT",
 	u"pos" : u"Top right",

--- a/libqnotero/preferences.py
+++ b/libqnotero/preferences.py
@@ -27,6 +27,8 @@ from libqnotero.config import getConfig, setConfig
 from libqnotero.uiloader import UiLoader
 from libzotero.libzotero import valid_location
 
+icons = [u'', u'qnotero-monochrome-white.svg', u'qnotero-monochrome-black.svg']
+
 class Preferences(QDialog, UiLoader):
 
 	"""Qnotero preferences dialog"""
@@ -67,6 +69,8 @@ class Preferences(QDialog, UiLoader):
 			if theme == getConfig(u"theme").lower():
 				self.ui.comboBoxTheme.setCurrentIndex(i)
 			i += 1
+		icon = getConfig(u"iconOverride")
+		self.ui.comboBoxIcon.setCurrentIndex(icons.index(icon) if icon in icons else 0)
 		self.setStyleSheet(self.qnotero.styleSheet())
 		self.adjustSize()
 
@@ -83,6 +87,7 @@ class Preferences(QDialog, UiLoader):
 			self.ui.checkBoxAutoUpdateCheck.isChecked())
 		setConfig(u"zoteroPath", self.ui.lineEditZoteroPath.text())
 		setConfig(u"theme", self.ui.comboBoxTheme.currentText().capitalize())
+		setConfig(u"iconOverride", icons[self.ui.comboBoxIcon.currentIndex()])
 		self.qnotero.saveState()
 		self.qnotero.reInit()
 		QDialog.accept(self)

--- a/libqnotero/qnotero.py
+++ b/libqnotero/qnotero.py
@@ -35,7 +35,7 @@ class Qnotero(QMainWindow, UiLoader):
 
 	"""The main class of the Qnotero GUI"""
 
-	version = '2.1.0'
+	version = '2.2.1'
 
 	def __init__(self, systray=True, debug=False, reset=False, parent=None):
 

--- a/libqnotero/qnotero.py
+++ b/libqnotero/qnotero.py
@@ -35,7 +35,7 @@ class Qnotero(QMainWindow, UiLoader):
 
 	"""The main class of the Qnotero GUI"""
 
-	version = '2.2.1'
+	version = '2.1.1'
 
 	def __init__(self, systray=True, debug=False, reset=False, parent=None):
 

--- a/libqnotero/qnotero.py
+++ b/libqnotero/qnotero.py
@@ -35,7 +35,7 @@ class Qnotero(QMainWindow, UiLoader):
 
 	"""The main class of the Qnotero GUI"""
 
-	version = '2.0.0'
+	version = '2.1.0'
 
 	def __init__(self, systray=True, debug=False, reset=False, parent=None):
 
@@ -209,7 +209,7 @@ class Qnotero(QMainWindow, UiLoader):
 			self.noteProvider = GnoteProvider(self)
 		self.zotero = LibZotero(getConfig(u"zoteroPath"), self.noteProvider)
 		if hasattr(self, u"sysTray"):
-			self.sysTray.setIcon(self.theme.icon(u"qnotero"))
+			self.sysTray.updateIcon()
 
 	def restoreState(self):
 
@@ -294,6 +294,13 @@ class Qnotero(QMainWindow, UiLoader):
 		"""Load a theme"""
 
 		theme = getConfig(u'theme')
+		iconOverride = getConfig(u'iconOverride')
+		if iconOverride:
+			self.isThemeIcon = False
+			self.iconName = u'../' + iconOverride
+		else:
+			self.isThemeIcon = True
+			self.iconName = u'qnotero'
 		mod = __import__(u'libqnotero._themes.%s' % theme.lower(), fromlist= \
 			[u'dummy'])
 		cls = getattr(mod, theme.capitalize())

--- a/libqnotero/sysTray.py
+++ b/libqnotero/sysTray.py
@@ -36,7 +36,7 @@ class SysTray(QSystemTrayIcon):
 	
 		QSystemTrayIcon.__init__(self, qnotero)
 		self.qnotero = qnotero		
-		self.setIcon(self.qnotero.theme.icon("qnotero"))		
+		self.updateIcon()
 		self.menu = QMenu()
 		self.menu.addAction(self.qnotero.theme.icon("qnotero"), "Show",
 			self.qnotero.popUp)
@@ -47,7 +47,17 @@ class SysTray(QSystemTrayIcon):
 		self.setContextMenu(self.menu)
 		self.activated.connect(self.activate)
 		self.listenerActivated.connect(self.activate)
-				
+
+	def updateIcon(self):
+
+		"""
+		Reloads the systray icon according to the current settings
+		"""
+		
+		iconName = self.qnotero.iconName
+		overrideIconExt = None if self.qnotero.isThemeIcon else ''
+		self.setIcon(self.qnotero.theme.icon(iconName, overrideIconExt))
+
 	def activate(self, reason=None):
 	
 		"""
@@ -56,7 +66,6 @@ class SysTray(QSystemTrayIcon):
 		Keyword arguments:
 		reason -- the reason for activation (default=None)
 		"""
-	
 		
 		if reason == QSystemTrayIcon.Context:
 			return		

--- a/libqnotero/ui/preferences.ui
+++ b/libqnotero/ui/preferences.ui
@@ -24,7 +24,7 @@
    <item row="2" column="1">
     <widget class="QLineEdit" name="lineEditZoteroPath"/>
    </item>
-   <item row="7" column="0" colspan="4">
+   <item row="8" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -90,7 +90,33 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="4">
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_21">
+     <property name="text">
+      <string>Icon</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="3">
+    <widget class="QComboBox" name="comboBoxIcon">
+     <item>
+      <property name="text">
+       <string>Theme default</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Monochrome white</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Monochrome black</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="4">
     <widget class="QCheckBox" name="checkBoxAutoUpdateCheck">
      <property name="text">
       <string>Automatically check for updates on start-up</string>

--- a/resources/qnotero-monochrome-black.svg
+++ b/resources/qnotero-monochrome-black.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128.78999"
+   height="128.78999"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="qnotero-monochrome-bright.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="109.90586"
+     inkscape:cy="36.231705"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:snap-page="false"
+     inkscape:object-paths="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-center="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="845"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-global="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-object-midpoints="false"
+     inkscape:snap-bbox-midpoints="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(4,-939.96685)">
+    <g
+       transform="matrix(1.0020651,0,0,0.99793916,1.7677668,0)"
+       style="font-size:116.10423279000001173px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       id="text3055">
+      <path
+         d="m 24.522771,962.18561 c 27.076189,0 54.152377,-10e-6 81.228569,0 -17.677831,23.36616 -34.834155,35.54813 -53.494741,58.12249 l 44.717935,0 5.987636,26.5179 -90.710503,0 c 18.837915,-22.6763 35.598381,-35.4001 54.381229,-58.12251 l -42.110125,0 -5.987634,-26.51788"
+         style="font-weight:bold;-inkscape-font-specification:Sans Bold;fill:#000000"
+         id="path3060"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/resources/qnotero-monochrome-white.svg
+++ b/resources/qnotero-monochrome-white.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128.78999"
+   height="128.78999"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="qnotero-monochrome-bright.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="109.90586"
+     inkscape:cy="36.231705"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:snap-page="false"
+     inkscape:object-paths="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-center="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="845"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-global="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-object-midpoints="false"
+     inkscape:snap-bbox-midpoints="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(4,-939.96685)">
+    <g
+       transform="matrix(1.0020651,0,0,0.99793916,1.7677668,0)"
+       style="font-size:116.10423278999999752px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       id="text3055">
+      <path
+         d="m 24.522771,962.18561 c 27.076189,0 54.152377,-10e-6 81.228569,0 -17.677831,23.36616 -34.834155,35.54813 -53.494741,58.12249 l 44.717935,0 5.987636,26.5179 -90.710503,0 c 18.837915,-22.6763 35.598381,-35.4001 54.381229,-58.12251 l -42.110125,0 -5.987634,-26.51788"
+         style="font-weight:bold;-inkscape-font-specification:Sans Bold;fill:#ffffff"
+         id="path3060"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/setup-windows.py
+++ b/setup-windows.py
@@ -70,6 +70,7 @@ setup(
 			],
 		}],
 	data_files = [
+		('resources', glob.glob('resources/*.svg')),
 		('resources/default', glob.glob('resources/default/*')),
 		('resources/elementary', glob.glob('resources/elementary/*')),		
 		('resources/tango', glob.glob('resources/tango/*')),

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name="qnotero",
 	data_files=[
 		("/usr/share/qnotero", ["COPYING"]),
 		("/usr/share/applications", ["data/qnotero.desktop"]),
+		("/usr/share/qnotero/resources", glob.glob("resources/*.svg")),
 		("/usr/share/qnotero/resources/default",
 			glob.glob("resources/default/*")),
 		("/usr/share/qnotero/resources/elementary",


### PR DESCRIPTION
I would appreciate it very much if you could push these changes to Launchpad.
#1. Fixes #23

![bildschirmfoto vom 2016-08-02 13 51 02](https://cloud.githubusercontent.com/assets/6557139/17327421/32c0e36c-58b8-11e6-9248-52122b0f58a8.png)

![bildschirmfoto vom 2016-08-02 13 51 44](https://cloud.githubusercontent.com/assets/6557139/17327431/44750480-58b8-11e6-9d10-30b7e7a6034e.png)
#2. Fixes #24

It has been observerd that Zotero encodes its strings _sometimes_ twice recursively. The modifications of this commit try to cope with that by decoding each string up to three times.

Probably this also fixes #1?
